### PR TITLE
Mctruth

### DIFF
--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -269,7 +269,7 @@ void Analysis::Execute() {
 
     maxElePtrue = 0;
     while(GenParticle *part = (GenParticle*) itParticle()){
-      if(part->PID == 11){
+      if(part->PID == 11 && part->Status == 1){
 	elePtrue = part->PT;
 	if(elePtrue > maxElePtrue){
 	  maxElePtrue = elePtrue;

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -87,7 +87,6 @@ void Analysis::Execute() {
   const Int_t NfinalStateBins = BinScheme("finalState")->GetNumBins();
   const Int_t NptjetBins = BinScheme("pt_jet")->GetNumBins();
 
-
   // sets of histogram sets
   // - `histSet` is a data structure for storing and organizing pointers to
   //   sets of histograms (`Histos` objects)
@@ -96,7 +95,6 @@ void Analysis::Execute() {
   //         better data structure
   Histos *histSet[NptBins][NxBins][NzBins][NqBins][NyBins][NfinalStateBins];
   Histos *histSetJets[NptjetBins][NxBins][NqBins][NyBins];
-  Histos *histSetDIS[NxBins][NqBins][NyBins];
   
   std::vector<Histos*> histSetList;
   std::vector<Histos*> histSetListJets;
@@ -134,6 +132,8 @@ void Analysis::Execute() {
               HS->DefineHist1D("x","x","",NBINS,1e-3,1.0,true,true);
               HS->DefineHist1D("y","y","",NBINS,1e-5,1,true);
               HS->DefineHist1D("W","W","GeV",NBINS,0,15);
+	      // -- DIS kinematics resolution
+	      HS->DefineHist1D("xRes","x - x_{true}","", NBINS, -1, 1);                                                                                           	     
               // -- hadron 4-momentum
               HS->DefineHist1D("pLab","p_{lab}","GeV",NBINS,0,10);
               HS->DefineHist1D("pTlab","p_{T}^{lab}","GeV",NBINS,1e-2,3,true);
@@ -237,7 +237,6 @@ void Analysis::Execute() {
   cout << sep << endl;
 
 
-
   // vars
   Double_t eleP,maxEleP;
   int pid,bFinalState;
@@ -291,14 +290,8 @@ void Analysis::Execute() {
     kin->GetJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);
     // calculate DIS kinematics
     kin->CalculateDISbyElectron();
-    // calculate true DIS kinematics                                                                                                                                                                                              
+    // calculate true DIS kinematics                                                                                                                                                         
     kinTrue->CalculateDISbyElectron();
-
-
-
-
-
-    
 
     // track loop
     itTrack.Reset();
@@ -312,7 +305,6 @@ void Analysis::Execute() {
       auto kv = PIDtoEnum.find(pid);
       if(kv!=PIDtoEnum.end()) bFinalState = kv->second;
       else continue;
-
 
       // get parent particle, to check if pion is from vector meson
       GenParticle *trkParticle = (GenParticle*)trk->Particle.GetObject();
@@ -378,6 +370,8 @@ void Analysis::Execute() {
           H->Hist("x")->Fill(kin->x);
           H->Hist("W")->Fill(kin->W);
           H->Hist("y")->Fill(kin->y);
+	  // DIS kinematics resolution
+	  H->Hist("xRes")->Fill(kin->x - kinTrue->x);
           // hadron 4-momentum
           H->Hist("pLab")->Fill(kin->pLab);
           H->Hist("pTlab")->Fill(kin->pTlab);

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -284,7 +284,7 @@ void Analysis::Execute() {
     };
 
     // get hadronic final state variables
-    kin->GetHadronicFinalState(itTrack, itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itPIDSystemsTrack, itParticle);
+    kin->GetHadronicFinalState(itTrack, itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);
     // get vector of jets
     // should this have an option for clustering method?
     kin->GetJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);

--- a/src/Analysis.h
+++ b/src/Analysis.h
@@ -81,6 +81,7 @@ class Analysis : public TNamed
     Histos *HS;
     SimpleTree *ST;
     Kinematics *kin;
+    Kinematics *kinTrue;
     TString infileName,outfileName;
     TFile *outFile;
     Double_t eleBeamEn = 5; // GeV

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -174,41 +174,31 @@ void Kinematics::CalculateHadronKinematics() {
 
 // get PID information from PID systems tracks
 int getTrackPID(Track *track, TObjArrayIter itParticle, TObjArrayIter itPIDSystemsTrack){
-  GenParticle *trackParticle = (GenParticle*)track->Particle.GetObject();                                                                                                                                            
-  GenParticle *detectorParticle;                                                                                                                                                                                                 
-  int pidOut = -1;                                                                                                                                                                                                  
-  while(Track *detectorTrack = (Track*)itPIDSystemsTrack() ){                                                                                                                                                              
-    detectorParticle = (GenParticle*)detectorTrack->Particle.GetObject();                                                                                                                                                             
-    if( detectorParticle == trackParticle ) pidOut = detectorTrack->PID;                                                                                                                                               
-  }                                                                                                                                                                                                                                         
+  GenParticle *trackParticle = (GenParticle*)track->Particle.GetObject();                                                                                                                      
+  GenParticle *detectorParticle;                                                                                                                                                       
+  int pidOut = -1;                                                                                                                                                                      
+  while(Track *detectorTrack = (Track*)itPIDSystemsTrack() ){                                                                                                                               
+    detectorParticle = (GenParticle*)detectorTrack->Particle.GetObject();                                                                                                              
+    if( detectorParticle == trackParticle ) pidOut = detectorTrack->PID;                                                                                                                    
+  }
+  
   return pidOut;
 }
 
 
 // calculates hadronic final state variables from DELPHES tree branches
 // expects 'vecElectron' set
-void Kinematics::GetHadronicFinalState(TObjArrayIter itTrack, TObjArrayIter itEFlowTrack, TObjArrayIter itEFlowPhoton, TObjArrayIter itEFlowNeutralHadron, TObjArrayIter itPIDSystemsTrack, TObjArrayIter itParticle){
+void Kinematics::GetHadronicFinalState(TObjArrayIter itTrack, TObjArrayIter itEFlowTrack, TObjArrayIter itEFlowPhoton, TObjArrayIter itEFlowNeutralHadron, TObjArrayIter itParticle){
   itTrack.Reset();
   itEFlowTrack.Reset();
   itEFlowPhoton.Reset();
   itEFlowNeutralHadron.Reset();
-  itPIDSystemsTrack.Reset();
 
   itParticle.Reset();
   while(Track *track = (Track*)itTrack() ){  
     TLorentzVector  trackp4 = track->P4();
     if(!isnan(trackp4.E())){
-      if( std::abs(track->Eta) >= 4.0  ){ 
-	int pidTrack = getTrackPID(track, itParticle, itPIDSystemsTrack);
-	float trackPt = trackp4.Pt();
-	float trackEta = trackp4.Eta();
-	float trackPhi = trackp4.Phi();
-	float corrmass = correctMass(pidTrack);
-
-	float trackMass = trackp4.M();
-	if(corrmass!=0) trackMass = corrmass;
-	trackp4.SetPtEtaPhiM(trackPt, trackEta, trackPhi, trackMass);
-	
+      if( std::abs(track->Eta) >= 4.0  ){ 	
 	sigmah += (trackp4.E() - trackp4.Pz());
 	Pxh += trackp4.Px();
 	Pyh +=trackp4.Py();
@@ -219,15 +209,6 @@ void Kinematics::GetHadronicFinalState(TObjArrayIter itTrack, TObjArrayIter itEF
     TLorentzVector eflowTrackp4 = eflowTrack->P4();
     if(!isnan(eflowTrackp4.E())){
       if(std::abs(eflowTrack->Eta) < 4.0){
-	int pidTrack = getTrackPID(eflowTrack, itParticle, itPIDSystemsTrack);
-	float trackPt = eflowTrackp4.Pt();
-	float trackEta = eflowTrackp4.Eta();
-	float trackPhi = eflowTrackp4.Phi();
-	float trackMass = eflowTrackp4.M();
-	float corrmass = correctMass(pidTrack);
-	if(corrmass!=0) trackMass = corrmass;
-	eflowTrackp4.SetPtEtaPhiM(trackPt, trackEta, trackPhi, trackMass);
-	
 	sigmah += (eflowTrackp4.E() - eflowTrackp4.Pz());
 	Pxh += eflowTrackp4.Px();
 	Pyh += eflowTrackp4.Py();

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -41,7 +41,7 @@ class Kinematics : public TObject
   
     void getqWQuadratic();
     void CalculateHadronKinematics();
-    void GetHadronicFinalState(TObjArrayIter itTrack, TObjArrayIter itEFlowTrack, TObjArrayIter itEFlowPhoton, TObjArrayIter itEFlowNeutralHadron, TObjArrayIter itPIDSystemsTrack, TObjArrayIter itParticle);
+    void GetHadronicFinalState(TObjArrayIter itTrack, TObjArrayIter itEFlowTrack, TObjArrayIter itEFlowPhoton, TObjArrayIter itEFlowNeutralHadron, TObjArrayIter itParticle);
 
     void GetJets(TObjArrayIter itEFlowTrack, TObjArrayIter itEFlowPhoton, TObjArrayIter itEFlowNeutralHadron, TObjArrayIter itParticle);
   


### PR DESCRIPTION
Added Kinematics object to store true kinematic variables, taking scattered electron from GenParticle Delphes bank. (also removed use of PID banks in hadronic final state variable function, as it wasn't necessary and wouldn't be immediately compatible with the Athena.tcl card.)