### PR TITLE
add depolarization calculations

### DIFF
--- a/macro/analysis_asymmetry.C
+++ b/macro/analysis_asymmetry.C
@@ -1,0 +1,30 @@
+R__LOAD_LIBRARY(Largex)
+
+// test new SimpleTree class
+void analysis_asymmetry(
+    TString infiles="datarec/arc/main_subset_10/*.root", /* delphes tree(s) */
+    Double_t eleBeamEn=5, /* electron beam energy [GeV] */
+    Double_t ionBeamEn=41, /* ion beam energy [GeV] */
+    Double_t crossingAngle=0, /* crossing angle [mrad] */
+    TString outfilePrefix="asym" /* output filename prefix*/
+) {
+
+  // setup analysis ========================================
+  AnalysisDelphes *A = new AnalysisDelphes(
+      infiles,
+      eleBeamEn,
+      ionBeamEn,
+      crossingAngle,
+      outfilePrefix
+      );
+
+  //A->maxEvents = 10000;
+  A->writeSimpleTree = true;
+
+  // set binning scheme ====================================
+  /* do nothing -> single bin */
+
+
+  // perform the analysis ==================================
+  A->Execute();
+};

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -574,9 +574,9 @@ void Kinematics::CalculateJetKinematics(fastjet::PseudoJet jet){
 // test a fake asymmetry, for fit code validation
 // - assigns `tSpin` based on desired fake asymmetry
 void Kinematics::InjectFakeAsymmetry() {
-  // modulations
+  // modulations, including depolarization factors [1807.10606 eq. 2.2-3]
   moduVal[0] = TMath::Sin(phiH-phiS); // sivers
-  moduVal[1] = TMath::Sin(phiH+phiS); // transversity*collins
+  moduVal[1] = TMath::Sin(phiH+phiS) * depolP1; // transversity*collins
   // fake amplitudes
   ampVal[0] = 0.1;
   ampVal[1] = 0.1;
@@ -584,8 +584,8 @@ void Kinematics::InjectFakeAsymmetry() {
   asymInject = 0;
   asymInject +=  ampVal[0]/0.2 * x * moduVal[0];
   asymInject += -ampVal[1]/0.2 * x * moduVal[1];
-  // apply polarization and depolarization factors
-  asymInject *= pol; // TODO: include depol. factor
+  // apply polarization
+  asymInject *= pol;
   // generate random number in [0,1]
   RN = RNG->Uniform();
   tSpin = (RN<0.5*(1+asymInject)) ? 1 : -1;

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -78,6 +78,16 @@ class Kinematics : public TObject
     // polarization
     Double_t pol;
 
+    // depolarization
+    Double_t gamma,epsilon;
+    // - factors A,B,C,V,W from [hep-ph/0611265] using notation from [1408.5721]
+    Double_t depolA, depolB, depolC, depolV, depolW;
+    // - ratios of factors, following notation of [1807.10606] eq. 2.3 (cf. eqs. 2.2a,b)
+    Double_t depolP1; // for A_UT*sin(phiH+phiS) (collins), A_UT*sin(3phiH-phiS) (pretzelosity)
+    Double_t depolP2; // for A_LL*const
+    Double_t depolP3; // for twist-3 A_UT
+    Double_t depolP4; // for A_LL*cos(phiH)
+
     // 4-vectors
     // - lab frame
     TLorentzVector vecEleBeam, vecIonBeam;
@@ -122,15 +132,6 @@ class Kinematics : public TObject
 
 
     // boost calculations
-    // - calculate boost vectors
-    void SetBoostVecs() {
-      // c.o.m. frame of virtual photon and ion
-      CvecBoost = vecQ + vecIonBeam;
-      Cboost = -1*CvecBoost.BoostVector();
-      // ion rest frame
-      IvecBoost = vecIonBeam;
-      Iboost = -1*IvecBoost.BoostVector();
-    };
     // - boost from Lab frame to photon+ion C.o.m. frame
     void BoostToComFrame(TLorentzVector Lvec, TLorentzVector &Cvec) {
       Cvec=Lvec; Cvec.Boost(Cboost); };

--- a/src/SimpleTree.cxx
+++ b/src/SimpleTree.cxx
@@ -17,6 +17,10 @@ SimpleTree::SimpleTree(TString treeName_, Kinematics *K_)
   T->Branch("PhiH",      &(K->phiH),   "PhiH/D");
   T->Branch("PhiS",      &(K->phiS),   "PhiS/D");
   T->Branch("Pol",       &(K->pol),    "Pol/D");
+  T->Branch("Depol1",    &(K->depolP1),"Depol1/D");
+  T->Branch("Depol2",    &(K->depolP2),"Depol2/D");
+  T->Branch("Depol3",    &(K->depolP3),"Depol3/D");
+  T->Branch("Depol4",    &(K->depolP4),"Depol4/D");
   T->Branch("Spin_idx",  &(K->tSpin),  "Spin_idx/I");
   T->Branch("Weight",    &(weight),    "Weight/D");
 };

--- a/tutorial/analysis_template.C
+++ b/tutorial/analysis_template.C
@@ -21,7 +21,7 @@ void analysis_template(
       outfilePrefix
       );
   //A->maxEvents = 10000; // use this to limit the number of events
-  //A->writeSimpleTree = true; // write SimpleTree (for one bin)
+  A->writeSimpleTree = true; // write SimpleTree (for one bin)
 
   // set reconstruction method =============================
   // - see `Analysis` constructor for methods


### PR DESCRIPTION
close https://github.com/c-dilks/largex-eic/issues/14

depolarization calculations:
https://github.com/c-dilks/largex-eic/blob/f1508ec586cd20374fc2d1346dce66d45e79e37b/src/Kinematics.cxx#L113-L131

These calculations should be double checked (added to the list in https://github.com/c-dilks/largex-eic/issues/28)

- depolarization calculations are performed in `Kinematics::CalculateDIS`
- implemented in `Kinematics`, `SimpleTree`, and fit code submodule; validated with fake asymmetry injection
- boost vector calculations moved to  `Kinematics::CalculateDIS`