### PR TITLE
add bin number access to NodePath

### DIFF
--- a/src/BinSet.cxx
+++ b/src/BinSet.cxx
@@ -76,6 +76,21 @@ void BinSet::BinLog(TAxis *ax) {
 }; 
 
 
+// get minimum or maximum of this BinSet (note: each bin must actually have min and max set)
+Double_t BinSet::GetMin() {
+  Double_t min = 1e6;
+  TObjArrayIter next(binList);
+  while(CutDef *cut = (CutDef*) next()) min = cut->GetMin() < min ? cut->GetMin() : min;
+  return min;
+};
+Double_t BinSet::GetMax() {
+  Double_t max = -1e6;
+  TObjArrayIter next(binList);
+  while(CutDef *cut = (CutDef*) next()) max = cut->GetMax() > max ? cut->GetMax() : max;
+  return max;
+};
+
+
 BinSet::~BinSet() {
 };
 

--- a/src/BinSet.h
+++ b/src/BinSet.h
@@ -34,6 +34,10 @@ class BinSet : public TObject
     TObjArray *GetBinList() { return binList; };
     Int_t GetNumBins() { return (Int_t) binList->GetEntries(); };
 
+    // get minimum or maximum of this BinSet (note: each bin must actually have min and max set)
+    Double_t GetMin();
+    Double_t GetMax();
+
     // accessors
     TString GetVarName() { return varName; };
     TString GetVarTitle() { return varTitle; };
@@ -70,7 +74,7 @@ class BinSet : public TObject
     static void BinLog(TAxis *ax);
 
   private:
-    TObjArray *binList;
+    TObjArray *binList; // array of `CutDef*`s
     TString varName,varTitle;
 
   ClassDef(BinSet,1);

--- a/src/DAG.cxx
+++ b/src/DAG.cxx
@@ -111,10 +111,11 @@ void DAG::RemoveEdge(Node *inN, Node *outN) {
 // - primary usage is to add a layer of bins from a BinSet
 void DAG::AddLayer(BinSet *BS) {
   std::vector<Node*> nodes;
-  int cnt=0;
+  int binNum=0; // enumerate bin number
   TObjArrayIter next(BS->GetBinList());
   while(CutDef *cut = (CutDef*) next()) {
-    nodes.push_back(new Node( NT::bin, cut->GetVarName()+Form("_%d",cnt++), cut ));
+    nodes.push_back(new Node( NT::bin, cut->GetVarName()+Form("_%d",binNum), cut, binNum ));
+    binNum++;
   };
   AddLayer(nodes);
   layerMap.insert(std::pair<TString,BinSet*>(BS->GetVarName(),new BinSet(*BS)));

--- a/src/Node.cxx
+++ b/src/Node.cxx
@@ -7,10 +7,11 @@ using std::cerr;
 using std::endl;
 
 // constructor
-Node::Node(Int_t nodeType_, TString id_, CutDef *cut_)
+Node::Node(Int_t nodeType_, TString id_, CutDef *cut_, Int_t binNum_)
   : nodeType(nodeType_)
   , id(id_)
   , cut(cut_)
+  , binNum(binNum_)
   , active(true)
   , debug(false)
 {

--- a/src/Node.h
+++ b/src/Node.h
@@ -38,8 +38,8 @@ class Node : public TObject
   public:
 
     // constructor: nodeType (see NT above), and unique ID string;
-    // a CutDef can be stored too, useful for bin nodes
-    Node(Int_t nodeType_=NT::bin, TString id_="0", CutDef *cut_=nullptr);
+    // a CutDef and bin number can be stored too, useful for bin nodes
+    Node(Int_t nodeType_=NT::bin, TString id_="0", CutDef *cut_=nullptr, Int_t binNum_=-1);
     ~Node();
 
     // accessors and modifiers
@@ -47,6 +47,8 @@ class Node : public TObject
     void SetNodeType(Int_t nodeType_) { nodeType=nodeType_; };
     TString GetID() { return id; };
     void SetID(TString id_) { id=id_; };
+    Int_t GetBinNum() { return binNum; };
+    void SetBinNum(Int_t binNum_) { binNum=binNum_; };
     CutDef *GetCut() { return cut; };
     TString GetCutType();
     TString GetVarName();
@@ -139,6 +141,7 @@ class Node : public TObject
     Bool_t debug;
     Int_t nodeType;
     TString id;
+    Int_t binNum;
     Bool_t active;
     std::vector<Node*> inputList;
     std::vector<Node*> outputList;

--- a/src/NodePath.cxx
+++ b/src/NodePath.cxx
@@ -7,11 +7,19 @@ NodePath::NodePath()
 {
 };
 
-// return a string of bin names
+// return a string of bin names -- for pretty print
 TString NodePath::BinListString() {
   TString ret = "[";
   for(auto it : GetSortedBins()) ret += " " + it->GetID();
   ret += " ]";
+  return ret;
+};
+
+// return a string of bin names -- for object names
+TString NodePath::BinListName() {
+  TString ret = "";
+  for(auto it : GetSortedBins()) ret += "_" + it->GetID();
+  ret(TRegexp("^_")) = "";
   return ret;
 };
 

--- a/src/NodePath.h
+++ b/src/NodePath.h
@@ -12,6 +12,7 @@
 #include "TObject.h"
 #include "TNamed.h"
 #include "TString.h"
+#include "TRegexp.h"
 
 // largex-eic
 #include "CutDef.h"
@@ -31,7 +32,8 @@ class NodePath : public TObject
      * - use these methods to get specific nodes, along with things the nodes holds such as cuts
      * - this class stores the list unsorted; use the sort methods to traverse the linked list in order 
      */
-    TString BinListString(); // return a string of bin names
+    TString BinListName(); // return a string of bin names, formatted for object names: `"bin1_bin2_bin3"`
+    TString BinListString(); // return a string of bin names, formatted for printing: `"[ bin1 bin2 bin3 ]"`
     void PrintBinList(); // print a string of node names
     TString CutListString(); // return a string of cuts (CutDef titles)
     Node *GetBinNode(TString varName); // return the bin node for the given variable name


### PR DESCRIPTION
### change log:
- add `BinSet::GetMin()` and `BinSet::GetMax()`, to access the minimum and maximum of a set of bins
- add `binNum` to `Node`, to store a bin number in a bin node; add accessor and modifier `Node::Get/SetBinNum()`
- add `NodePath::BinListName()` to return a convenient string giving a unique name for the list of bin nodes in the `NodePath`; this can be used to make unique names for `TCanvas` etc.
- bin numbers are now assigned in `DAG::AddLayer`, which is the main method used to add `BinSet` layers to the DAG, and is called by `HistosDAG::Build`
- update `macro/ci/postprocess_resolution.C` to make use of all above changes, and help support `PostProcessor::DrawInBins`; these updates will facilitate the production of resolution and coverage proposal plots @mfmceneaney @cpecar 


close https://github.com/c-dilks/largex-eic/issues/75
