### PR TITLE
enforce correct crossing angle sign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
-        run: root -b -q macro/ci/${{ matrix.amacro }}'("macro/ci/${{ matrix.config }}",5,41,25,"${{ matrix.name }}.${{ matrix.mode }}")'
+        run: root -b -q macro/ci/${{ matrix.amacro }}'("macro/ci/${{ matrix.config }}",5,41,-25,"${{ matrix.name }}.${{ matrix.mode }}")'
       - name: postprocess
         run: root -b -q macro/ci/${{ matrix.pmacro }}'("out/${{ matrix.name }}.${{ matrix.mode }}.root")'
       - name: artifacts

--- a/macro/analysis_PvsEta.C
+++ b/macro/analysis_PvsEta.C
@@ -8,7 +8,7 @@ void analysis_PvsEta(
     TString infiles="datarec/in.config", /* delphes tree(s) */
     Double_t eleBeamEn=10, /* electron beam energy [GeV] */
     Double_t ionBeamEn=100, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="coverage_pVsEtabins" /* output filename prefix*/
 ) {
 

--- a/macro/analysis_asymmetry.C
+++ b/macro/analysis_asymmetry.C
@@ -44,7 +44,7 @@ void analysis_asymmetry(
     TString infiles="datarec/in.config", /* delphes tree(s) */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="asymmetry" /* output filename prefix*/
 ) {
 

--- a/macro/analysis_coverage.C
+++ b/macro/analysis_coverage.C
@@ -8,7 +8,7 @@ void analysis_coverage(
     TString infiles="datarec/in.config", /* delphes tree(s) */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="coverage" /* output filename prefix*/
 ) {
 

--- a/macro/analysis_phi_crosscheck.C
+++ b/macro/analysis_phi_crosscheck.C
@@ -4,7 +4,7 @@ void analysis_phi_crosscheck(
     TString infiles="datarec/tutorial.config", /* list of input files */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="phi.crosscheck" /* output filename prefix*/
 ) {
 

--- a/macro/analysis_purity.C
+++ b/macro/analysis_purity.C
@@ -5,7 +5,7 @@ void analysis_purity(
     TString infiles="datarec/in.config", /* delphes tree(s) */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString methodname="ele", /*reconstruction method name*/
     TString outfilePrefix="resolutions" /* output filename prefix*/
     

--- a/macro/ci/analysis_xq.C
+++ b/macro/ci/analysis_xq.C
@@ -5,7 +5,7 @@ void analysis_xq(
     TString infiles="datarec/canyonlands/5x41/files.config",
     Double_t eleBeamEn=5,
     Double_t ionBeamEn=41,
-    Double_t crossingAngle=25,
+    Double_t crossingAngle=-25,
     TString outfilePrefix="coverage.fullsim"
 ) {
 

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -10,13 +10,18 @@ Kinematics::Kinematics(
     )
 {
 
-  // convert crossing angle to rad
-  crossAng *= 1e-3;
-
   // set ion mass
   IonMass = ProtonMass();
 
+  // revise crossing angle
+  crossAng *= 1e-3; // mrad -> rad
+  crossAng = -1*TMath::Abs(crossAng); // take -1*abs(crossAng) to enforce the correct sign
+
   // set beam 4-momenta
+  // - electron beam points toward negative z
+  // - ion beam points toward positive z, negative x
+  // - crossing angle about y-axis is therefore negative, in right-handed coord. system
+  // - north is +x, east is +z
   Double_t momEleBeam = EMtoP(enEleBeam,ElectronMass());
   Double_t momIonBeam = EMtoP(enIonBeam,IonMass);
   vecEleBeam.SetPxPyPzE(
@@ -26,7 +31,7 @@ Kinematics::Kinematics(
       enEleBeam
       );
   vecIonBeam.SetPxPyPzE(
-      -momIonBeam * TMath::Sin(crossAng),
+      momIonBeam * TMath::Sin(crossAng),
       0,
       momIonBeam * TMath::Cos(crossAng),
       enIonBeam

--- a/tutorial/analysis_coverage.C
+++ b/tutorial/analysis_coverage.C
@@ -6,7 +6,7 @@ void analysis_coverage(
     TString infiles="datarec/tutorial.config", /* list of input files */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="coverage" /* output filename prefix*/
 ) {
 

--- a/tutorial/analysis_dd4hep.C
+++ b/tutorial/analysis_dd4hep.C
@@ -20,7 +20,7 @@ void analysis_dd4hep(
     TString infiles="tutorial/s3files.config", /* list of input files (S3 URLs, plus other columns) */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="tutorial.dd4hep" /* output filename prefix*/)
 {
 

--- a/tutorial/analysis_qbins.C
+++ b/tutorial/analysis_qbins.C
@@ -5,7 +5,7 @@ void analysis_qbins(
     TString infiles="datarec/tutorial.config", /* list of input files */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="tutorial.qbins" /* output filename prefix*/
 ) {
 

--- a/tutorial/analysis_template.C
+++ b/tutorial/analysis_template.C
@@ -8,7 +8,7 @@ void analysis_template(
     TString infiles="datarec/tutorial.config", /* list of input files */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="tutorial.template" /* output filename prefix*/
 ) {
 

--- a/tutorial/analysis_testDAG.C
+++ b/tutorial/analysis_testDAG.C
@@ -5,7 +5,7 @@ void analysis_testDAG(
     TString infiles="datarec/tutorial.config", /* list of input files */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="testDAG" /* output filename prefix*/
 ) {
 

--- a/tutorial/analysis_xqbins.C
+++ b/tutorial/analysis_xqbins.C
@@ -8,7 +8,7 @@ void analysis_xqbins(
     TString infiles="datarec/tutorial.config", /* list of input files */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="tutorial.xqbins" /* output filename prefix*/
 ) {
 

--- a/tutorial/analysis_yRatio.C
+++ b/tutorial/analysis_yRatio.C
@@ -5,7 +5,7 @@ void analysis_yRatio(
     TString infiles="datarec/tutorial.config", /* list of input files */
     Double_t eleBeamEn=5, /* electron beam energy [GeV] */
     Double_t ionBeamEn=41, /* ion beam energy [GeV] */
-    Double_t crossingAngle=25, /* crossing angle [mrad] */
+    Double_t crossingAngle=-25, /* crossing angle [mrad] */
     TString outfilePrefix="yRatio" /* output filename prefix*/
 ) {
 


### PR DESCRIPTION
close https://github.com/c-dilks/largex-eic/issues/89
- now it does not matter which sign is used at the macro level
- macro default args have been updated anyway