### PR TITLE
debug JB and DA issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.name }}-${{ matrix.mode }}-plots
-          path: out/${{ matrix.name }}.${{ matrix.mode }}.images
+          path: |
+            out/*.images
+            out/*.root
 
 # run benchmark macros matrix for fullsim
   benchmark-fullsim:
@@ -295,7 +297,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.name }}-${{ matrix.mode }}-plots
-          path: out/${{ matrix.name }}.${{ matrix.mode }}.images
+          path: |
+            out/*.images
+            out/*.root
 
 # run reconstruction methods matrix for fastsim
   benchmark-recon:
@@ -368,7 +372,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.name }}-${{ matrix.recon }}-plots
-          path: out/${{ matrix.name }}.${{ matrix.recon }}.images
+          path: |
+            out/*.images
+            out/*.root
 
 
 # ARTIFACTS ---------------------------------------------------------------------------
@@ -393,6 +399,7 @@ jobs:
           rm -vr results/x_*
           rm -vr results/delphes-*-output
           find results -name "*.pdf" -print | xargs rm -v
+          find results -name "*.root" -print | xargs rm -v
           rm -v results/y-minima*/canv*.png
       - name: organize
         run: macro/ci/organize-artifacts.sh results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam-en: 10
-  pbeam-en: 100
+  ebeam-en: 18
+  pbeam-en: 275
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
         with:
           name: ${{ matrix.name }}-${{ matrix.mode }}-plots
           path: |
-            out/*.images
+            out/*.images/*.png
             out/*.root
 
 # run benchmark macros matrix for fullsim
@@ -298,7 +298,7 @@ jobs:
         with:
           name: ${{ matrix.name }}-${{ matrix.mode }}-plots
           path: |
-            out/*.images
+            out/*.images/*.png
             out/*.root
 
 # run reconstruction methods matrix for fastsim
@@ -373,7 +373,7 @@ jobs:
         with:
           name: ${{ matrix.name }}-${{ matrix.recon }}-plots
           path: |
-            out/*.images
+            out/*.images/*.png
             out/*.root
 
 
@@ -394,15 +394,20 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: results
+      - name: tree
+        run: tree results
       - name: cull
         run: |
           rm -vr results/x_*
           rm -vr results/delphes-*-output
-          find results -name "*.pdf" -print | xargs rm -v
           find results -name "*.root" -print | xargs rm -v
           rm -v results/y-minima*/canv*.png
+      - name: tree
+        run: tree results
       - name: organize
         run: macro/ci/organize-artifacts.sh results
+      - name: tree
+        run: tree results
       - name: upload
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam-en: 18
-  pbeam-en: 275
+  ebeam-en: 10
+  pbeam-en: 100
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,7 @@ jobs:
           rm -vr results/x_*
           rm -vr results/delphes-*-output
           find results -name "*.root" -print | xargs rm -v
-          rm -v results/y-minima*/canv*.png
+          rm -v results/y-minima*/*/canv*.png
       - name: tree
         run: tree results
       - name: organize

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ container/img
 get-files.sh
 results*
 *.xsec
+tags
 
 # users' custom ignores
 datagen/escalate

--- a/macro/ci/analysis_p_eta.C
+++ b/macro/ci/analysis_p_eta.C
@@ -18,7 +18,7 @@ void analysis_p_eta(
 
   A->SetReconMethod(reconMethod); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
-  A->writeSimpleTree = true;
+  // A->writeSimpleTree = true;
 
   // define cuts ===========================================
   A->AddBinScheme("w");  A->BinScheme("w")->BuildBin("Min",3.0); // W > 3 GeV

--- a/macro/ci/analysis_p_eta.C
+++ b/macro/ci/analysis_p_eta.C
@@ -18,6 +18,7 @@ void analysis_p_eta(
 
   A->SetReconMethod(reconMethod); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
+  A->writeSimpleTree = true;
 
   // define cuts ===========================================
   A->AddBinScheme("w");  A->BinScheme("w")->BuildBin("Min",3.0); // W > 3 GeV

--- a/macro/ci/analysis_x_q2.C
+++ b/macro/ci/analysis_x_q2.C
@@ -7,7 +7,7 @@ void analysis_x_q2(
     Double_t ionBeamEn=100,
     Double_t crossingAngle=-25,
     TString outfilePrefix="resolution.fastsim",
-    TString reconMethod="JB"
+    TString reconMethod="Ele"
 ) {
 
   // setup analysis ========================================

--- a/macro/ci/analysis_x_q2.C
+++ b/macro/ci/analysis_x_q2.C
@@ -3,8 +3,8 @@ R__LOAD_LIBRARY(Largex)
 // analysis in bins of (x,Q2)
 void analysis_x_q2(
     TString infiles="datarec/delphes.config", // default, for manual local testing
-    Double_t eleBeamEn=5,
-    Double_t ionBeamEn=41,
+    Double_t eleBeamEn=10,
+    Double_t ionBeamEn=100,
     Double_t crossingAngle=-25,
     TString outfilePrefix="resolution.fastsim",
     TString reconMethod="Ele"

--- a/macro/ci/analysis_x_q2.C
+++ b/macro/ci/analysis_x_q2.C
@@ -18,6 +18,7 @@ void analysis_x_q2(
 
   A->SetReconMethod(reconMethod); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
+  A->writeSimpleTree = true;
 
   // define cuts ===========================================
   A->AddBinScheme("w");  A->BinScheme("w")->BuildBin("Min",3.0); // W > 3 GeV

--- a/macro/ci/analysis_x_q2.C
+++ b/macro/ci/analysis_x_q2.C
@@ -7,7 +7,7 @@ void analysis_x_q2(
     Double_t ionBeamEn=100,
     Double_t crossingAngle=-25,
     TString outfilePrefix="resolution.fastsim",
-    TString reconMethod="Ele"
+    TString reconMethod="JB"
 ) {
 
   // setup analysis ========================================

--- a/macro/ci/analysis_x_q2.C
+++ b/macro/ci/analysis_x_q2.C
@@ -2,7 +2,7 @@ R__LOAD_LIBRARY(Largex)
 
 // analysis in bins of (x,Q2)
 void analysis_x_q2(
-    TString infiles="datarec/canyonlands-v1.2/5x41/files.config", // default, for manual local testing
+    TString infiles="datarec/delphes.config", // default, for manual local testing
     Double_t eleBeamEn=5,
     Double_t ionBeamEn=41,
     Double_t crossingAngle=-25,

--- a/macro/ci/analysis_x_q2.C
+++ b/macro/ci/analysis_x_q2.C
@@ -18,7 +18,7 @@ void analysis_x_q2(
 
   A->SetReconMethod(reconMethod); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
-  A->writeSimpleTree = true;
+  // A->writeSimpleTree = true;
 
   // define cuts ===========================================
   A->AddBinScheme("w");  A->BinScheme("w")->BuildBin("Min",3.0); // W > 3 GeV

--- a/macro/ci/organize-artifacts.sh
+++ b/macro/ci/organize-artifacts.sh
@@ -54,12 +54,12 @@ echo "------------- merge recon methods -------------------"
 # loop through recon* directories
 ls | grep -E '^recon-' |\
 while read dirRecon; do
-  mv -v *.images/* ./; rm -r *.images
   method=$(echo $dirRecon | sed 's/-plots$//g' | sed 's/^.*-//g')
   dirOut=$(echo $dirRecon | sed "s/-$method//g" | sed 's/^recon-/&methods-/g')
   echo "MOVE ARTIFACTS IN $dirRecon/ FOR METHOD \"$method\" TO $dirOut/"
   mkdir -p $dirOut
   pushd $dirRecon
+  mv -v *.images/* ./; rm -r *.images
   for file in *; do
     mv -v $file ../$dirOut/$(echo $file | sed "s/^.*\./&$method./g")
   done

--- a/macro/ci/organize-artifacts.sh
+++ b/macro/ci/organize-artifacts.sh
@@ -54,6 +54,7 @@ echo "------------- merge recon methods -------------------"
 # loop through recon* directories
 ls | grep -E '^recon-' |\
 while read dirRecon; do
+  mv -v *.images/* ./; rm -r *.images
   method=$(echo $dirRecon | sed 's/-plots$//g' | sed 's/^.*-//g')
   dirOut=$(echo $dirRecon | sed "s/-$method//g" | sed 's/^recon-/&methods-/g')
   echo "MOVE ARTIFACTS IN $dirRecon/ FOR METHOD \"$method\" TO $dirOut/"

--- a/macro/ci/organize-artifacts.sh
+++ b/macro/ci/organize-artifacts.sh
@@ -25,6 +25,7 @@ while read dirFast; do
   # move fastsim artifacts to output directory, and add suffix to file name
   echo "MOVE AND RENAME artifacts in $dirFast -> $dirOut"
   pushd $dirFast
+  mv -v *.images/* ./; rm -r *.images
   for file in *; do
     mv -v $file ../$dirOut/$(echo $file | sed 's/^.*\./&fastsim./g')
   done
@@ -33,6 +34,7 @@ while read dirFast; do
   # repeat for fullsim artifacts
   echo "MOVE AND RENAME artifacts in $dirFull -> $dirOut"
   pushd $dirFull
+  mv -v *.images/* ./; rm -r *.images
   for file in *; do
     mv -v $file ../$dirOut/$(echo $file | sed 's/^.*\./&fullsim./g')
   done

--- a/macro/ci/postprocess_x_q2.C
+++ b/macro/ci/postprocess_x_q2.C
@@ -33,6 +33,8 @@ void postprocess_x_q2(TString infile="out/resolution.fastsim.root") {
     histList.push_back("y_Res");
     histList.push_back("pT_Res");
     histList.push_back("Q2_Res");
+    histList.push_back("Nu_Res");
+    histList.push_back("W_Res");
     histList.push_back("phiH_Res");
     histList.push_back("phiS_Res");
   } else {

--- a/macro/ci/postprocess_x_q2.C
+++ b/macro/ci/postprocess_x_q2.C
@@ -2,7 +2,7 @@ R__LOAD_LIBRARY(Largex)
 
 // make grids of plots of (x,Q2) bins
 // - depending on infile, different histograms will be drawn
-void postprocess_x_q2(TString infile="out/coverage.fullsim.root") {
+void postprocess_x_q2(TString infile="out/resolution.fastsim.root") {
 
   // set histogram lists, based on infile name
   std::vector<TString> histList;

--- a/macro/ci/postprocess_x_q2.C
+++ b/macro/ci/postprocess_x_q2.C
@@ -37,6 +37,9 @@ void postprocess_x_q2(TString infile="out/resolution.fastsim.root") {
     histList.push_back("W_Res");
     histList.push_back("phiH_Res");
     histList.push_back("phiS_Res");
+    histList.push_back("z_Res");
+    histList.push_back("mX_Res");
+    histList.push_back("xF_Res");
   } else {
     fprintf(stderr,"ERROR: histList not defined for specified infile name\n");
     return;

--- a/macro/ci/postprocess_x_q2.C
+++ b/macro/ci/postprocess_x_q2.C
@@ -37,6 +37,7 @@ void postprocess_x_q2(TString infile="out/resolution.fastsim.root") {
     histList.push_back("W_Res");
     histList.push_back("phiH_Res");
     histList.push_back("phiS_Res");
+    histList.push_back("hadCount");
   } else {
     fprintf(stderr,"ERROR: histList not defined for specified infile name\n");
     return;

--- a/macro/ci/postprocess_x_q2.C
+++ b/macro/ci/postprocess_x_q2.C
@@ -37,7 +37,6 @@ void postprocess_x_q2(TString infile="out/resolution.fastsim.root") {
     histList.push_back("W_Res");
     histList.push_back("phiH_Res");
     histList.push_back("phiS_Res");
-    histList.push_back("hadCount");
   } else {
     fprintf(stderr,"ERROR: histList not defined for specified infile name\n");
     return;

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -359,8 +359,6 @@ void Analysis::Prepare() {
         NBINS,-TMath::Pi(),TMath::Pi(),
         NBINS,-TMath::Pi(),TMath::Pi()
         );
-    // -- other / debugging
-    HS->DefineHist1D("hadCount","nHadRec/nHadGen","", NBINS, 0, 3);
   });
   HD->ExecuteAndClearOps();
 
@@ -666,8 +664,6 @@ void Analysis::FillHistosTracks() {
     dynamic_cast<TH2*>(H->Hist("x_RvG"))->Fill(kinTrue->x,kin->x,wTrack);
     dynamic_cast<TH2*>(H->Hist("phiH_RvG"))->Fill(kinTrue->phiH,kin->phiH,wTrack);
     dynamic_cast<TH2*>(H->Hist("phiS_RvG"))->Fill(kinTrue->phiS,kin->phiS,wTrack);
-    // -- other / debugging
-    if(kinTrue->countHadrons>0) H->Hist("hadCount")->Fill(((double)kin->countHadrons)/((double)kinTrue->countHadrons),wTrack);
   });
   // execute the payload
   // - save time and don't call `ClearOps` (next loop will overwrite lambda)

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -316,12 +316,12 @@ void Analysis::Prepare() {
     HS->DefineHist1D("y_Res","y-y_{true}","", NBINS, -0.2, 0.2);
     HS->DefineHist1D("Q2_Res","Q2-Q2_{true}","GeV^{2}", NBINS, -20, 20);
     HS->DefineHist1D("W_Res","W-W_{true}","GeV", NBINS, -20, 20);
-    HS->DefineHist1D("Nu_Res","#nu-#nu_{true}","GeV", NBINS, -50, 50);
+    HS->DefineHist1D("Nu_Res","#nu-#nu_{true}","GeV", NBINS, -100, 100);
     HS->DefineHist1D("phiH_Res","#phi_{h}-#phi_{h}^{true}","", NBINS, -TMath::Pi(), TMath::Pi());
     HS->DefineHist1D("phiS_Res","#phi_{S}-#phi_{S}^{true}","", NBINS, -TMath::Pi(), TMath::Pi());
     HS->DefineHist1D("pT_Res","pT-pT^{true}","GeV", NBINS, -1.5, 1.5);
     HS->DefineHist1D("z_Res","z-z^{true}","", NBINS, -1.5, 1.5);
-    HS->DefineHist1D("mX_Res","mX-mX^{true}","GeV", NBINS, -1.5, 1.5);
+    HS->DefineHist1D("mX_Res","mX-mX^{true}","GeV", NBINS, -5, 5);
     HS->DefineHist1D("xF_Res","xF-xF^{true}","", NBINS, -1.5, 1.5);
     HS->DefineHist2D("Q2vsXtrue","x","Q^{2}","","GeV^{2}",
         20,1e-4,1,

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -320,6 +320,9 @@ void Analysis::Prepare() {
     HS->DefineHist1D("phiH_Res","#phi_{h}-#phi_{h}^{true}","", NBINS, -TMath::Pi(), TMath::Pi());
     HS->DefineHist1D("phiS_Res","#phi_{S}-#phi_{S}^{true}","", NBINS, -TMath::Pi(), TMath::Pi());
     HS->DefineHist1D("pT_Res","pT-pT^{true}","GeV", NBINS, -1.5, 1.5);
+    HS->DefineHist1D("z_Res","z-z^{true}","", NBINS, -1.5, 1.5);
+    HS->DefineHist1D("mX_Res","mX-mX^{true}","GeV", NBINS, -1.5, 1.5);
+    HS->DefineHist1D("xF_Res","xF-xF^{true}","", NBINS, -1.5, 1.5);
     HS->DefineHist2D("Q2vsXtrue","x","Q^{2}","","GeV^{2}",
         20,1e-4,1,
         10,1,1e4,
@@ -651,6 +654,9 @@ void Analysis::FillHistosTracks() {
     H->Hist("phiH_Res")->Fill( Kinematics::AdjAngle(kin->phiH - kinTrue->phiH), wTrack );
     H->Hist("phiS_Res")->Fill( Kinematics::AdjAngle(kin->phiS - kinTrue->phiS), wTrack );
     H->Hist("pT_Res")->Fill( kin->pT - kinTrue->pT, wTrack );
+    H->Hist("z_Res")->Fill( kin->z - kinTrue->z, wTrack );
+    H->Hist("mX_Res")->Fill( kin->mX - kinTrue->mX, wTrack );
+    H->Hist("xF_Res")->Fill( kin->xF - kinTrue->xF, wTrack );
     dynamic_cast<TH2*>(H->Hist("Q2vsXtrue"))->Fill(kinTrue->x,kinTrue->Q2,wTrack);
     if(kinTrue->z!=0) dynamic_cast<TH2*>(H->Hist("Q2vsX_zres"))->Fill(
       kinTrue->x,kinTrue->Q2,wTrack*( fabs(kinTrue->z - kin->z)/(kinTrue->z) ) );

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -314,8 +314,8 @@ void Analysis::Prepare() {
     // -- resolutions
     HS->DefineHist1D("x_Res","x-x_{true}","", NBINS, -0.5, 0.5);
     HS->DefineHist1D("y_Res","y-y_{true}","", NBINS, -0.2, 0.2);
-    HS->DefineHist1D("Q2_Res","Q2-Q2_{true}","GeV^{2}", NBINS, -0.5, 0.5);
-    HS->DefineHist1D("W_Res","W-W_{true}","GeV", NBINS, -5, 5);
+    HS->DefineHist1D("Q2_Res","Q2-Q2_{true}","GeV^{2}", NBINS, -20, 20);
+    HS->DefineHist1D("W_Res","W-W_{true}","GeV", NBINS, -20, 20);
     HS->DefineHist1D("Nu_Res","#nu-#nu_{true}","GeV", NBINS, -50, 50);
     HS->DefineHist1D("phiH_Res","#phi_{h}-#phi_{h}^{true}","", NBINS, -TMath::Pi(), TMath::Pi());
     HS->DefineHist1D("phiS_Res","#phi_{S}-#phi_{S}^{true}","", NBINS, -0.1*TMath::Pi(), 0.1*TMath::Pi());
@@ -359,6 +359,8 @@ void Analysis::Prepare() {
         NBINS,-TMath::Pi(),TMath::Pi(),
         NBINS,-TMath::Pi(),TMath::Pi()
         );
+    // -- other / debugging
+    HS->DefineHist1D("hadCount","nHadRec/nHadGen","", NBINS, 0, 3);
   });
   HD->ExecuteAndClearOps();
 
@@ -664,6 +666,8 @@ void Analysis::FillHistosTracks() {
     dynamic_cast<TH2*>(H->Hist("x_RvG"))->Fill(kinTrue->x,kin->x,wTrack);
     dynamic_cast<TH2*>(H->Hist("phiH_RvG"))->Fill(kinTrue->phiH,kin->phiH,wTrack);
     dynamic_cast<TH2*>(H->Hist("phiS_RvG"))->Fill(kinTrue->phiS,kin->phiS,wTrack);
+    // -- other / debugging
+    if(kinTrue->countHadrons>0) H->Hist("hadCount")->Fill(((double)kin->countHadrons)/((double)kinTrue->countHadrons),wTrack);
   });
   // execute the payload
   // - save time and don't call `ClearOps` (next loop will overwrite lambda)

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -314,7 +314,9 @@ void Analysis::Prepare() {
     // -- resolutions
     HS->DefineHist1D("x_Res","x-x_{true}","", NBINS, -0.5, 0.5);
     HS->DefineHist1D("y_Res","y-y_{true}","", NBINS, -0.2, 0.2);
-    HS->DefineHist1D("Q2_Res","Q2-Q2_{true}","GeV", NBINS, -0.5, 0.5);
+    HS->DefineHist1D("Q2_Res","Q2-Q2_{true}","GeV^{2}", NBINS, -0.5, 0.5);
+    HS->DefineHist1D("W_Res","W-W_{true}","GeV", NBINS, -5, 5);
+    HS->DefineHist1D("Nu_Res","#nu-#nu_{true}","GeV", NBINS, -50, 50);
     HS->DefineHist1D("phiH_Res","#phi_{h}-#phi_{h}^{true}","", NBINS, -TMath::Pi(), TMath::Pi());
     HS->DefineHist1D("phiS_Res","#phi_{S}-#phi_{S}^{true}","", NBINS, -0.1*TMath::Pi(), 0.1*TMath::Pi());
     HS->DefineHist1D("pT_Res","pT-pT^{true}","GeV", NBINS, -1.5, 1.5);
@@ -644,6 +646,8 @@ void Analysis::FillHistosTracks() {
     H->Hist("x_Res")->Fill( kin->x - kinTrue->x, wTrack );
     H->Hist("y_Res")->Fill( kin->y - kinTrue->y, wTrack );
     H->Hist("Q2_Res")->Fill( kin->Q2 - kinTrue->Q2, wTrack );
+    H->Hist("W_Res")->Fill( kin->W - kinTrue->W, wTrack );
+    H->Hist("Nu_Res")->Fill( kin->Nu - kinTrue->Nu, wTrack );
     H->Hist("phiH_Res")->Fill( Kinematics::AdjAngle(kin->phiH - kinTrue->phiH), wTrack );
     H->Hist("phiS_Res")->Fill( Kinematics::AdjAngle(kin->phiS - kinTrue->phiS), wTrack );
     H->Hist("pT_Res")->Fill( kin->pT - kinTrue->pT, wTrack );

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -318,7 +318,7 @@ void Analysis::Prepare() {
     HS->DefineHist1D("W_Res","W-W_{true}","GeV", NBINS, -20, 20);
     HS->DefineHist1D("Nu_Res","#nu-#nu_{true}","GeV", NBINS, -50, 50);
     HS->DefineHist1D("phiH_Res","#phi_{h}-#phi_{h}^{true}","", NBINS, -TMath::Pi(), TMath::Pi());
-    HS->DefineHist1D("phiS_Res","#phi_{S}-#phi_{S}^{true}","", NBINS, -0.1*TMath::Pi(), 0.1*TMath::Pi());
+    HS->DefineHist1D("phiS_Res","#phi_{S}-#phi_{S}^{true}","", NBINS, -TMath::Pi(), TMath::Pi());
     HS->DefineHist1D("pT_Res","pT-pT^{true}","GeV", NBINS, -1.5, 1.5);
     HS->DefineHist2D("Q2vsXtrue","x","Q^{2}","","GeV^{2}",
         20,1e-4,1,

--- a/src/AnalysisDD4hep.cxx
+++ b/src/AnalysisDD4hep.cxx
@@ -167,7 +167,7 @@ void AnalysisDD4hep::process_event()
 
 
     // calculate true DIS kinematics
-    kinTrue->CalculateDIS(reconMethod); // generated (truth)
+    if(!(kinTrue->CalculateDIS(reconMethod))) continue; // generated (truth)
 
     // collect reconstructed particles
     std::vector<Particles> recopart;
@@ -241,7 +241,7 @@ void AnalysisDD4hep::process_event()
     kin->Pyh = head_vecHadron.Py();
 
     // calculate DIS kinematics
-    kin->CalculateDIS(reconMethod); // reconstructed
+    if(!(kin->CalculateDIS(reconMethod))) continue; // reconstructed
 
     // calculate hadron kinematics
     for(auto part : recopart)

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -277,6 +277,8 @@ void AnalysisDelphes::Execute() {
 
   // finish execution
   Finish();
+  cout << "DEBUG recon: good=" << kin->countGood << "  bad=" << kin->countBad << endl;  // DEBUG //////////////
+  cout << "DEBUG true:  good=" << kinTrue->countGood << "  bad=" << kinTrue->countBad << endl;  // DEBUG //////////////
 };
 
 

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -56,7 +56,6 @@ void AnalysisDelphes::Execute() {
   TObjArrayIter itEFlowTrack(tr->UseBranch("EFlowTrack"));
   TObjArrayIter itEFlowPhoton(tr->UseBranch("EFlowPhoton"));
   TObjArrayIter itEFlowNeutralHadron(tr->UseBranch("EFlowNeutralHadron"));
-  TObjArrayIter itPIDSystemsTrack(tr->UseBranch("PIDSystemsTrack"));
   TObjArrayIter itpfRICHTrack(tr->UseBranch("pfRICHTrack"));
   TObjArrayIter itDIRCepidTrack(tr->UseBranch("barrelDIRC_epidTrack"));
   TObjArrayIter itDIRChpidTrack(tr->UseBranch("barrelDIRC_hpidTrack"));
@@ -151,13 +150,13 @@ void AnalysisDelphes::Execute() {
         itEFlowTrack,
         itEFlowPhoton,
         itEFlowNeutralHadron,
-        itParticle,
         itpfRICHTrack,
         itDIRCepidTrack, itDIRChpidTrack,
         itBTOFepidTrack, itBTOFhpidTrack,
         itdualRICHagTrack, itdualRICHcfTrack
         );
     kinTrue->GetHadronicFinalStateTrue(itParticle);
+
     // calculate DIS kinematics
     kin->CalculateDIS(reconMethod); // reconstructed
     kinTrue->CalculateDIS(reconMethod); // generated (truth)

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -276,8 +276,7 @@ void AnalysisDelphes::Execute() {
 
   // finish execution
   Finish();
-  cout << "DEBUG recon: good=" << kin->countGood << "  bad=" << kin->countBad << endl;  // DEBUG //////////////
-  cout << "DEBUG true:  good=" << kinTrue->countGood << "  bad=" << kinTrue->countBad << endl;  // DEBUG //////////////
+  cout << "DEBUG PID: nSmeared=" << kin->countPIDsmeared << "  nNotSmeared=" << kin->countPIDtrue << endl;
 };
 
 

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -158,8 +158,8 @@ void AnalysisDelphes::Execute() {
     kinTrue->GetHadronicFinalStateTrue(itParticle);
 
     // calculate DIS kinematics
-    kin->CalculateDIS(reconMethod); // reconstructed
-    kinTrue->CalculateDIS(reconMethod); // generated (truth)
+    if(!(kin->CalculateDIS(reconMethod))) continue; // reconstructed
+    if(!(kinTrue->CalculateDIS(reconMethod))) continue; // generated (truth)
 
     // get vector of jets
     // TODO: should this have an option for clustering method?

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -67,6 +67,7 @@ Kinematics::Kinematics(
   // random number generator (for asymmetry injection
   RNG = new TRandomMixMax(91874); // (TODO: fixed seed?)
 
+  countGood=countBad=0; // DEBUG /////////////////////
 };
 
 
@@ -416,14 +417,16 @@ void Kinematics::GetHadronicFinalState(
             );
 	if(pid != -1){
 	  trackp4.SetPtEtaPhiM(trackp4.Pt(),trackp4.Eta(),trackp4.Phi(),correctMass(pid));	  
+          countGood++; // DEBUG /////////////////////
+          sigmah += (trackp4.E() - trackp4.Pz());
+          Pxh += trackp4.Px();
+          Pyh +=trackp4.Py();	
+          this->TransformToHeadOnFrame(trackp4,trackp4);
+          Hsigmah += (trackp4.E() - trackp4.Pz());
+          HPxh += trackp4.Px();
+          HPyh +=trackp4.Py();
 	}
-	sigmah += (trackp4.E() - trackp4.Pz());
-        Pxh += trackp4.Px();
-        Pyh +=trackp4.Py();	
-        this->TransformToHeadOnFrame(trackp4,trackp4);
-        Hsigmah += (trackp4.E() - trackp4.Pz());
-        HPxh += trackp4.Px();
-        HPyh +=trackp4.Py();
+        else countBad++; // DEBUG /////////////////////
       }
     }    
   }

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -134,7 +134,7 @@ void Kinematics::GetQWNu_quadratic(){
     Nu = vecIonBeam.Dot(vecQ)/IonMass;
 
   } else {
-    // DEBUG TODO: this happens a lot more often if mainFrame==fLab
+    // this happens a lot more often if mainFrame==fLab
     if(b*b<4*a*c) cerr << "ERROR: negative discriminant in Kinematics::GetQWNu_quadratic; skipping event" << endl;
     else cerr << "ERROR: zero denominator in Kinematics::GetQWNu_quadratic; skipping event" << endl;
     reconOK = false;
@@ -509,7 +509,7 @@ void Kinematics::GetHadronicFinalState(
         }
         else { // otherwise, assume true PID
           countPIDtrue++;
-          //continue; // drop events if PID not smeared // DEBUG TODO: this is more realistic, but resolutions are waaay worse...
+          //continue; // drop events if PID not smeared // TODO [critical]: this is more realistic, but resolutions are much worse
         }
 
         if(mainFrame==fHeadOn) this->TransformToHeadOnFrame(trackp4,trackp4);

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -21,7 +21,7 @@ Kinematics::Kinematics(
   // set main frame, used for calculations where there is ambiguity which frame is the correct frame to use
   mainFrame = fHeadOn; // fLab, fHeadOn
   // set method for determining `vecQ` 4-momentum components for certain recon methods (JB,DA,(e)Sigma)
-  qComponentsMethod = qQuadratic; // qQuadratic, qHadronic, qElectronic
+  qComponentsMethod = qHadronic; // qQuadratic, qHadronic, qElectronic
   /////////////////////////////////////////////////////////////
 
   // set beam 4-momenta

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -21,7 +21,7 @@ Kinematics::Kinematics(
   // set main frame, used for calculations where there is ambiguity which frame is the correct frame to use
   mainFrame = fHeadOn; // fLab, fHeadOn
   // set method for determining `vecQ` 4-momentum components for certain recon methods (JB,DA,(e)Sigma)
-  qComponentsMethod = qHadronic; // qQuadratic, qHadronic, qElectronic
+  qComponentsMethod = qQuadratic; // qQuadratic, qHadronic, qElectronic
   /////////////////////////////////////////////////////////////
 
   // set beam 4-momenta

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -80,8 +80,7 @@ class Kinematics : public TObject
     // kinematics (should be Double_t, if going in SimpleTree)
     Double_t W,Q2,Nu,x,y,s; // DIS
     Double_t pLab,pTlab,phiLab,etaLab,z,pT,qT,mX,xF,phiH,phiS; // hadron
-    Double_t sigmah, Pxh, Pyh; // hadronic final state, lab frame
-    Double_t Hsigmah, HPxh, HPyh; // hadronic final state, head-on frame
+    Double_t sigmah, Pxh, Pyh; // hadronic final state variables
     TLorentzVector hadronSumVec;
 
     // nucleon transverse spin; if you set this externally,
@@ -222,7 +221,7 @@ class Kinematics : public TObject
     // tests and validation
     void ValidateHeadOnFrame();
 
-    Long64_t countGood,countBad; // DEBUG /////////////////////
+    Long64_t countPIDsmeared,countPIDtrue,countHadrons;
      
   protected:
 
@@ -273,6 +272,13 @@ class Kinematics : public TObject
     Double_t rotAboutX, rotAboutY;
     // other
     TLorentzVector vecSpin, IvecSpin;
+
+    // settings
+    Int_t mainFrame;
+    enum mainFrame_enum {fLab, fHeadOn};
+    Int_t qComponentsMethod;
+    enum qComponentsMethod_enum {qQuadratic, qHadronic, qElectronic};
+
 
 
   ClassDef(Kinematics,1);

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -81,7 +81,8 @@ class Kinematics : public TObject
     Double_t W,Q2,Nu,x,y,s; // DIS
     Double_t pLab,pTlab,phiLab,etaLab,z,pT,qT,mX,xF,phiH,phiS; // hadron
     Double_t sigmah, Pxh, Pyh; // hadronic final state, lab frame
-    Double_t Hsigmah, HPxh, HPyh; // hadronic final state, lab frame                                                                                                 
+    Double_t Hsigmah, HPxh, HPyh; // hadronic final state, head-on frame
+    TLorentzVector hadronSumVec;
 
     // nucleon transverse spin; if you set this externally,
     // it must be done before calculating `phiS` (before
@@ -225,14 +226,19 @@ class Kinematics : public TObject
      
   protected:
 
-    // protected calculators (called by public calculators)
+    // reconstruction methods
     void CalculateDISbyElectron();
     void CalculateDISbyJB();
     void CalculateDISbyDA();
     void CalculateDISbyMixed();
     void CalculateDISbySigma();
     void CalculateDISbyeSigma();
-    void getqWQuadratic();
+
+    // calculate 4-momenta components of q and W (`vecQ` and `vecW`) as well as
+    // derived invariants `W` and `nu`
+    void GetQWNu_electronic();
+    void GetQWNu_hadronic();
+    void GetQWNu_quadratic();
 
 
   private:

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -49,7 +49,6 @@ class Kinematics : public TObject
         TObjArrayIter itEFlowTrack,
         TObjArrayIter itEFlowPhoton,
         TObjArrayIter itEFlowNeutralHadron,
-        TObjArrayIter itParticle,
         TObjArrayIter itpfRICHTrack,
         TObjArrayIter itDIRCepidTrack,   TObjArrayIter itDIRChpidTrack,
         TObjArrayIter itBTOFepidTrack,   TObjArrayIter itBTOFhpidTrack,

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -220,6 +220,8 @@ class Kinematics : public TObject
     // tests and validation
     void ValidateHeadOnFrame();
 
+    Long64_t countGood,countBad; // DEBUG /////////////////////
+     
   protected:
 
     // protected calculators (called by public calculators)

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -40,7 +40,7 @@ class Kinematics : public TObject
     ~Kinematics();
 
     // SIDIS calculators
-    void CalculateDIS(TString recmethod);
+    Bool_t CalculateDIS(TString recmethod); // return true if succeeded
     void CalculateHadronKinematics();
 
     // final state accessors
@@ -142,6 +142,8 @@ class Kinematics : public TObject
     void BoostToBeamComFrame(TLorentzVector Lvec, TLorentzVector &Bvec);
     // - tranform from Lab frame `Lvec` to Head-on frame `Hvec`
     void TransformToHeadOnFrame(TLorentzVector Lvec, TLorentzVector &Hvec);
+    // transform from Head-on frame `Hvec` back to Lab frame `Lvec`
+    void TransformBackToLabFrame(TLorentzVector Hvec, TLorentzVector &Lvec);
 
 
     // misc calculations
@@ -240,6 +242,7 @@ class Kinematics : public TObject
     Double_t asymInject;
     TRandom *RNG;
     Float_t RN;
+    Bool_t reconOK;
 
     // - c.o.m. frame of virtual photon and ion
     TLorentzVector CvecBoost;


### PR DESCRIPTION
tries to address https://github.com/c-dilks/largex-eic/issues/110, but does not resolve

Instead, several small updates are implemented:
- in some places, there was some inconsistency of which frame the calculation was being performed in; in general, however, the difference between lab frame and head-on frame seems subdominant compared to the large difference in resolutions between electronic and hadronic methods
- add more resolution plots, and fix some axis ranges:
  - Nu
  - W
  - z
  - mX
  - xF
- rename `Kinematics::getqWQuadratic` to `Kinematics::GetQWNu_quadratic` and add two additional methods which serve the same purpose of calculating the components of q, W, and Nu:
  - `GetQWNu_electronic`, used by electron and mixed recon methods
  - `GetQWNu_hadronic`, which was an attempt to compare to `GetQWNu_quadratic`, but instead uses the full hadronic final state vector `hadronSumVec`; the resolutions seem similar, in some places a bit better, but the W resolution is now not centered around zero; this is likely because of #118 
- Add some test "settings" to `Kinematics`:
  - `mainFrame` selects which frame to use (lab frame or head-on frame), for cases where there is a bit of ambiguity which frame is the correct one to use
    - in general the frame choice doesn't seem to matter much, nor does using data with zero crossing angle
    - the discriminant in `GetQWNu_quadratic` is sometimes negative, when using the lab frame, but is always positive when using the head-on frame
      - when the discriminant is negative, the event is now skipped, since the quadratic roots are complex (implemented by making `Kinematics::CalculateDIS` return a boolean, indicating if the calculations were successful)
  - `qComponentsMethod` selects between the three `GetQWNu_*` methods, when using the DA, JB, sigma, and eSigma recon methods
- add `Kinematics::TransformBackToLabFrame`, which transforms from the head-on frame back to the lab frame
- add counters to check how many times the PID was smeared or not smeared
  - single tracks are omitted from output if PID is not smeared, but not from the hadronic final state calculations (`GetHadronicFinalState`)
-  update CI artifacts organization to support upload of output ROOT files, in particular, `SimpleTree` artifacts