### PR TITLE
test fastsim resolutions by comparing to truth ele method

### DIFF
--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -159,7 +159,7 @@ void AnalysisDelphes::Execute() {
 
     // calculate DIS kinematics
     if(!(kin->CalculateDIS(reconMethod))) continue; // reconstructed
-    if(!(kinTrue->CalculateDIS(reconMethod))) continue; // generated (truth)
+    if(!(kinTrue->CalculateDIS("Ele"))) continue; // generated (truth)
 
     // get vector of jets
     // TODO: should this have an option for clustering method?

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -158,8 +158,8 @@ void AnalysisDelphes::Execute() {
     kinTrue->GetHadronicFinalStateTrue(itParticle);
 
     // calculate DIS kinematics
-    if(!(kin->CalculateDIS(reconMethod))) continue; // reconstructed
-    if(!(kinTrue->CalculateDIS("Ele"))) continue; // generated (truth)
+    if(!(kin->CalculateDIS("Ele"))) continue; // reconstructed
+    if(!(kinTrue->CalculateDIS(reconMethod))) continue; // generated (truth)
 
     // get vector of jets
     // TODO: should this have an option for clustering method?


### PR DESCRIPTION
- test resolutions for each specific reconMethod by using:
  - use specified reconMethod for reconstructed kinematics
  - use electron reconMethod for generated kinematics (instead of the specified method, which is what we normally do)
- this tests if the apparent poor resolution in the hadronic methods
  is driven by poor agreement between true and reconstructed hadronic
  final states