### PR TITLE
automate delphes for S3 hepmc files

### DIFF
--- a/exeDelphes.sh
+++ b/exeDelphes.sh
@@ -24,7 +24,14 @@ if [ $# -lt 1 ]; then
 fi
 infile=$1
 if [ $# -ge 2 ]; then outfile=$2
-else outfile=$(echo $infile|sed 's/^.*\//datarec\//g'|sed 's/.hepmc.*$/.root/g'); fi
+else
+  if grep -qE '^datagen' <<< "$infile"; then
+    outfile=$(echo $infile|sed 's/^datagen/datarec/'|sed 's/.hepmc.*$/.root/g')
+    mkdir -p $(dirname $outfile)
+  else
+    outfile=$(echo $infile|sed 's/^.*\//datarec\//g'|sed 's/.hepmc.*$/.root/g')
+  fi
+fi
 if [ $# -ge 3 ]; then cardfile=$3; fi
 echo "infile = $infile"
 echo "outfile = $outfile"

--- a/macro/ci/analysis_x_q2.C
+++ b/macro/ci/analysis_x_q2.C
@@ -8,8 +8,8 @@ void analysis_x_q2(
     Double_t ionBeamEn=100,
     Double_t crossingAngle=-25,
     // TString outfilePrefix="resolution.fastsim",
-    TString outfilePrefix="resolution.fullsim",
-    // TString outfilePrefix="coverage.fastsim",
+    // TString outfilePrefix="resolution.fullsim",
+    TString outfilePrefix="coverage.fastsim",
     // TString outfilePrefix="coverage.fullsim",
     TString reconMethod="Ele"
 ) {

--- a/macro/ci/postprocess_x_q2.C
+++ b/macro/ci/postprocess_x_q2.C
@@ -2,7 +2,7 @@ R__LOAD_LIBRARY(Largex)
 
 // make grids of plots of (x,Q2) bins
 // - depending on infile, different histograms will be drawn
-void postprocess_x_q2(TString infile="out/resolution.fullsim.root") {
+void postprocess_x_q2(TString infile="out/coverage.fastsim.root") {
 
   // set histogram lists, based on infile name
   std::vector<TString> histList;

--- a/s3tools/README.md
+++ b/s3tools/README.md
@@ -6,6 +6,8 @@ repository
 For more details, see [S3 file storage documentation](https://doc.athena-eic.org/en/latest/howto/s3_file_storage.html)
 
 ## Quick Start
+
+### Full Simulations
 One top-level script automates all the work:
 - `s3tools/make-canyonlands-config.sh` (best to run from top-level directory)
   - running with no arguments will print the usage guide
@@ -25,20 +27,20 @@ One top-level script automates all the work:
   the [MinIO client](https://docs.min.io/docs/minio-client-complete-guide) first
   - (otherwise update your Singularity image)
 
-For fast simulations, one can use `make-fastsim-config.sh` to help in the creation
-of a config file for fast simulations. This script is used by the CI, but is also
-designed to be configurable to support any local organization of Delphes output
-files.
-- to download a set of `hepmc` files to the directory `datagen/10x100/Q2min1`, run
-  `s3tools/generate-hepmc-list.sh 10x100 1 | s3tools/download.sh datagen/10x100/Q2min1`
-  - run these scripts without arguments to print the usage guide
-  - limit the number of files downloaded by piping through `head` before `download.sh`
-- then run `delphes` on these files (a wrapper `./exeDelphes.sh` is provided, which
-  will use the configuration card stored in `cards/` by default)
-- finally, run `make-fastsim-config.sh`
-  - use `cat` to combine config files with differing Q2 minima
-
-
+### Fast Simulations
+Two options:
+- download `hepmc` files from S3 and run Delphes locally
+  - this is automated by `s3tools/make-fastsim-S3-config.sh`; run with no
+    arguments to print the usage guide, and note the arguments are a bit
+    different than those for the full simulation scripts
+  - this script can download `hepmc` files from S3, run Delphes on them, and
+    generate the config file
+    - Delphes will run using one thread per Q2 minimum; edit the script
+      to change this behavior
+  - similar to full simulations, you need to have the S3 access and secret
+    environment variables set in order to download `hepmc` files
+- alternatively, if you already have a directory of Delphes output ROOT files,
+  use use `make-fastsim-config.sh` to create a config file
 
 ## Accessing S3 Files
 - first, download the [MinIO client](https://docs.min.io/docs/minio-client-complete-guide)

--- a/s3tools/make-canyonlands-config.sh
+++ b/s3tools/make-canyonlands-config.sh
@@ -27,7 +27,8 @@ if [ $# -lt 2 ]; then
                c - just make the local config file, for local files
    
    - [limit]   integer>0 : only stream/download this many files per Q2 min
-               0         : stream/download all files (default)
+               0         : stream/download all files
+               default=5
    
    - [outputFile]: output file name (optional)
                    - default name is based on release version 
@@ -71,7 +72,7 @@ if [ "$mode" == "d" ]; then
     if [ $limit -gt 0 ]; then
       s3tools/generate-s3-list.sh "$sourceDir/minQ2=$Q2min" | head -n$limit | s3tools/download.sh "$targetDir/minQ2=$Q2min"
     else
-      s3tools/generate-s3-list.sh "$sourceDir/minQ2=$Q2min" | s3tools/download.sh "$targetDir/minQ2=$Q2min"
+      s3tools/generate-s3-list.sh "$sourceDir/minQ2=$Q2min" |                 s3tools/download.sh "$targetDir/minQ2=$Q2min"
     fi
   done
 fi

--- a/s3tools/make-canyonlands-config.sh
+++ b/s3tools/make-canyonlands-config.sh
@@ -50,7 +50,7 @@ if [ $# -lt 2 ]; then
 fi
 energy=$1
 mode=$2
-limit=0
+limit=5
 outFile=""
 if [ $# -ge 3 ]; then limit=$3; fi
 if [ $# -ge 4 ]; then outFile=$4; fi

--- a/s3tools/make-fastsim-S3-config.sh
+++ b/s3tools/make-fastsim-S3-config.sh
@@ -74,7 +74,7 @@ if [ "$mode" == "f" -o "$mode" == "a" ]; then
     echo "delphes log: " > $1/delphes.log
     for infile in $1/*.hepmc.gz; do 
       echo "RUN DELPHES ON $infile" >> $1/delphes.log
-      ./exeDelphes.sh $infile 2>&1 >> $1/delphes.log  # AQUI: seems to just be outputting to top-level datarec
+      ./exeDelphes.sh $infile 2>&1 >> $1/delphes.log
     done
     status "DONE running Delphes on directory $1"
   }

--- a/s3tools/make-fastsim-S3-config.sh
+++ b/s3tools/make-fastsim-S3-config.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+###################
+# TOP-LEVEL SCRIPT to automate the creation of a config file for fastsim files
+# - automates S3 downloading and delphes execution
+# - see also `s3tools/make-fastsim-config.sh` to generate a config file for
+#   a specific directory of Delphes output root files
+###################
+
+# usage:
+if [ $# -lt 3 ]; then
+  echo """
+  USAGE: $0 [energy] [local_dir] [mode] [limit(optional)]
+
+  provides automation for downloading hepmc files from S3, running
+  Delphes on them (one thread per Q2min), and finally the generation
+  of a config file
+
+   - [energy]: 5x41 5x100 10x100 10x275 18x275
+
+   - [local_dir]: local directory name
+     - hepmc files will be downloaded to datagen/[local_dir]
+     - Delphes output root files will appear in datarec/[local_dir]
+     - subdirectories with energy and Q2min are created within
+     - if you need to put files on a different disk, create or symlink
+       datagen/[local_dir] and datarec/[local_dir] beforehand
+
+   - [mode]:   a - run all the modes below
+               d - only download hepmc files
+               f - only run the delphes fast simulation
+               c - only generate the config file
+
+   - [limit]:  integer>0 : only download this many files per Q2 min
+               0         : download all files (default)
+               - default=5
+               - limit only applies to downloading
+
+  """
+  exit 2
+fi
+energy=$1
+locDir=$2
+mode=$3
+limit=5
+if [ $# -ge 4 ]; then limit=$4; fi
+
+# settings
+Q2minima=( 1000 100 10 1 ) # should be decreasing order
+genDir=datagen/$locDir
+recDir=datarec/$locDir
+configFile=$recDir/delphes.config
+
+# download hepmc files from S3
+function status { echo ""; echo "[+] $1"; }
+if [ "$mode" == "d" -o "$mode" == "a" ]; then
+  status "downloading files from S3..."
+  for Q2min in ${Q2minima[@]}; do
+    if [ $limit -gt 0 ]; then
+      s3tools/generate-hepmc-list.sh $energy $Q2min | head -n$limit | s3tools/download.sh "$genDir/$energy/minQ2=$Q2min"
+    else
+      s3tools/generate-hepmc-list.sh $energy $Q2min |                 s3tools/download.sh "$genDir/$energy/minQ2=$Q2min"
+    fi
+  done
+fi
+
+# run delphes
+if [ "$mode" == "f" -o "$mode" == "a" ]; then
+  status "clean Delphes output directories"
+  for Q2min in ${Q2minima[@]}; do
+    rm -rv $recDir/$energy/minQ2=$Q2min
+  done
+  status "running Delphes (one thread per Q2min)"
+  function runDelphes { 
+    echo "delphes log: " > $1/delphes.log
+    for infile in $1/*.hepmc.gz; do 
+      echo "RUN DELPHES ON $infile" >> $1/delphes.log
+      ./exeDelphes.sh $infile 2>&1 >> $1/delphes.log  # AQUI: seems to just be outputting to top-level datarec
+    done
+    status "DONE running Delphes on directory $1"
+  }
+  for Q2min in ${Q2minima[@]}; do
+    status "RUNNING DELPHES on energy=$1 Q2min=$Q2min..."
+    runDelphes "$genDir/$energy/minQ2=$Q2min" & # comment out `&` if you want to run single threaded
+  done
+  status "WAIT FOR DELPHES"
+  echo "  - quit by running: while [ 1 ]; do pkill DelphesHepMC3; done"
+  echo "  - monitor progress in log files in another window with:"
+  echo "    find $genDir -name \"delphes.log\" | xargs tail -F"
+  wait
+  status "DONE RUNNING DELPHES"
+fi
+
+# generate config file
+if [ "$mode" == "c" -o "$mode" == "a" ]; then
+  for Q2min in ${Q2minima[@]}; do
+    status "make config file for $recDir/$energy/minQ2=$Q2min"
+    s3tools/make-fastsim-config.sh $energy $Q2min $recDir/$energy/minQ2=$Q2min{,/delphes.config}
+  done
+  status "concatenate config files to target config file: $configFile"
+  > $configFile
+  for Q2min in ${Q2minima[@]}; do
+    cat $recDir/$energy/minQ2=$Q2min/delphes.config >> $configFile
+  done
+fi
+
+# output some info
+status "done building config file at:"
+echo "     $configFile"
+status "run root macros with parameters:"
+echo "     '(\"$configFile\",$(echo $energy|sed 's/x/,/'))'"
+echo ""
+if [ -n "$(grep UNKNOWN $configFile)" ]; then
+  >&2 echo "ERROR: missing some cross sections"
+  exit 1
+fi

--- a/s3tools/make-fastsim-config.sh
+++ b/s3tools/make-fastsim-config.sh
@@ -2,6 +2,7 @@
 
 ###################
 # TOP-LEVEL SCRIPT to automate the creation of a config file for fastsim files
+# - see also s3tools/make-fastsim-S3-config.sh, to automate S3 downloading and delphes execution
 ###################
 
 # usage:

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -276,7 +276,7 @@ void AnalysisDelphes::Execute() {
 
   // finish execution
   Finish();
-  cout << "DEBUG PID: nSmeared=" << kin->countPIDsmeared << "  nNotSmeared=" << kin->countPIDtrue << endl;
+  //cout << "DEBUG PID in HFS: nSmeared=" << kin->countPIDsmeared << "  nNotSmeared=" << kin->countPIDtrue << endl;
 };
 
 


### PR DESCRIPTION
add some scripts, in particular `s3tools/make-fastsim-S3-config.sh`, to
automate downloading `hepmc` files from S3, running Delphes on them, and
generate the config file.

close https://github.com/c-dilks/largex-eic/issues/94