### PR TITLE
normalize comparator hists by integral

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam_en: 18
-  pbeam_en: 275
+  ebeam_en: 10
+  pbeam_en: 100
   cross_ang: -25
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam_en: 10
-  pbeam_en: 100
+  ebeam_en: 18
+  pbeam_en: 275
   cross_ang: -25
 
 jobs:

--- a/src/PostProcessor.cxx
+++ b/src/PostProcessor.cxx
@@ -471,8 +471,9 @@ void PostProcessor::DrawInBins(
 
         // renormalize
         if(renormalize) {
+          // hist->Scale(1/hist->GetMaximum());
           // hist->Scale(1/hist->GetEntries());
-          hist->Scale(1/hist->GetMaximum());
+          hist->Scale(1/hist->Integral());
         }
 
         TString drawStr = "";


### PR DESCRIPTION
change normalization of compared histograms in DrawInBins to be via
histogram integrals, rather than by histogram maxima